### PR TITLE
Modifies chocolateyInstall.ps1 messages to English

### DIFF
--- a/chia-network/tools/chocolateyinstall.ps1
+++ b/chia-network/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
-﻿$ErrorActionPreference = 'Stop';
+$ErrorActionPreference = 'Stop'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url        = 'https://github.com/Chia-Network/chia-blockchain/releases/download/1.1.7/ChiaSetup-1.1.7.exe'
-$process	= "Chia"
+$process    = "Chia"
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
@@ -17,13 +17,11 @@ $packageArgs = @{
   silentArgs   = '/S'
 }
 
-$CheckProcess = Get-Process | Where-Object {$_.ProcessName -eq $process}
-If($CheckProcess -eq $null){
-	Write-Host "Prozess wird aktuell nicht ausgeführt"
-	} 
-	else {
-	Write-Host "Prozess wird aktuell ausgeführt"
+if (-not (Get-Process -Name $process -ErrorAction SilentlyContinue)) {
+    Write-Host "Process is not currently running."
+} else {
+    Write-Host "Process is currently running. Killing process '$process' before install."
     Stop-Process -Name $process
-	}
+}
 
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
The `chia-network` package had requested changes to the language in the messaging, as unless the software itself is only intended to be used in German-speaking locales it is preferred to have Chocolatey packages output messages in English.

This commit adjusts `chocolateyInstall.ps1` to match the messages in `chocolateybeforemodify.ps1`, along with a minor adjustment to the logic used.